### PR TITLE
更新GitHub Actions发布工作流，在打包时排除安装日志文件(seatunnel-install-log-*)、httpd配置文件…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
             --exclude='.web*' \
             --exclude='*.log' \
             --exclude='temp.*' \
+            --exclude='seatunnel-install-log-*' \
+            --exclude='.httpd.conf' \
+            --exclude='.*.pid' \
             .
           
       - name: Create Release


### PR DESCRIPTION
…(.httpd.conf)和PID文件(.*.pid)，避免临时文件被包含在发布包中。